### PR TITLE
Make accountId required, update flows and docs

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,0 +1,40 @@
+{{ if .Versions -}}
+{{   if .Unreleased.CommitGroups -}}
+<a name="unreleased"></a>
+## [Unreleased]
+
+{{     range .Unreleased.CommitGroups -}}
+### {{ .Title }}
+{{       range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{       end }}
+{{     end -}}
+{{   end -}}
+
+{{ range .Versions -}}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]{{ else }}{{ .Tag.Name }}{{ end }} - {{ datetime "2006-01-02" .Tag.Date }}
+{{   range .CommitGroups -}}
+### {{ .Title }}
+{{     range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{     end }}
+{{   end -}}
+
+{{   if .NoteGroups -}}
+{{     range .NoteGroups -}}
+### {{ .Title }}
+{{       range .Notes }}
+{{         .Body }}
+{{       end }}
+{{     end -}}
+{{   end -}}
+{{ end -}}
+
+[Unreleased]: {{ .Info.RepositoryURL }}/compare/{{ $latest := index .Versions 0 }}{{ $latest.Tag.Name }}...HEAD
+{{   range .Versions -}}
+{{     if .Tag.Previous -}}
+[{{ .Tag.Name }}]: {{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}
+{{     end -}}
+{{   end -}}
+{{ end -}}

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,39 @@
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: https://github.com/newrelic/deployment-marker-action
+options:
+  commits:
+    filters:
+      Type:
+        - docs
+        - feat
+        - fix
+
+  commit_groups:
+    title_maps:
+      docs: Documentation Updates
+      feat: Features
+      fix: Bug Fixes
+
+  refs:
+    actions:
+      - Closes
+      - Fixes
+      - Resolves
+
+  issues:
+    prefix:
+      - #
+
+  header:
+    pattern: "^(\\w*)(?:\\(([\\/\\w\\$\\.\\-\\*\\s]*)\\))?\\:\\s(.*)$"
+    pattern_maps:
+      - Type
+      - Scope
+      - Subject
+
+  notes:
+    keywords:
+      - BREAKING CHANGE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,12 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  - release
 
 jobs:
   basic_test:
     runs-on: ubuntu-latest
-    name: Release marker example
+    name: Deployment marker example
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -20,6 +18,7 @@ jobs:
         uses: ./
         with:
           apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
-          applicationId: ${{ secrets.APPLICATION_ID }}
-          revision: "deployment-marker-action-release:${{ env.RELEASE_VERSION }}"
+          accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
+          applicationId: ${{ secrets.NEW_RELIC_APPLICATION_ID }}
+          revision: "${{ github.repository }}:${{ env.RELEASE_VERSION }}"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
 #        uses: ./
 #        with:
 #          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+#          accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
 #          applicationId: 0
 #          revision: "deployment-marker-action-should-fail-test:${{ github.ref }}"
 
@@ -32,6 +33,7 @@ jobs:
         uses: ./
         with:
           apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+          accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
           applicationId: ${{ secrets.APPLICATION_ID }}
           revision: "deployment-marker-action-basic-test:${{ github.ref }}"
 
@@ -46,9 +48,9 @@ jobs:
         uses: ./
         with:
           apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+          accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
           applicationId: ${{ secrets.APPLICATION_ID }}
           revision: "deployment-marker-action-all-input-test-${{ github.sha }}"
           user: "hardcoded-test-username"                             # optional
           region: US                                                  # optional
-          accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}              # optional
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
           revision: "deployment-marker-action-all-input-test-${{ github.sha }}"
 
           # Optional
-          changelog: "See https://github.com/${{ github.repository }}/CHANGELOG.md for details"
+          changelog: "See https://github.com/${{ github.repository }}/blob/master/CHANGELOG.md for details"
           description: "Automated Deployment via Github Actions"
           region: ${{ secrets.NEW_RELIC_REGION }}
           user: "hardcoded-test-username"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Test deployment marker
         uses: ./
         with:
-          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
           accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
+          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
           applicationId: ${{ secrets.APPLICATION_ID }}
           revision: "deployment-marker-action-basic-test:${{ github.ref }}"
 
@@ -47,10 +47,14 @@ jobs:
       - name: Test deployment marker
         uses: ./
         with:
-          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
           accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
+          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
           applicationId: ${{ secrets.APPLICATION_ID }}
           revision: "deployment-marker-action-all-input-test-${{ github.sha }}"
-          user: "hardcoded-test-username"                             # optional
-          region: US                                                  # optional
+
+          # Optional
+          changelog: "See https://github.com/${{ github.repository }}/CHANGELOG.md for details"
+          description: "Automated Deployment via Github Actions"
+          region: ${{ secrets.NEW_RELIC_REGION }}
+          user: "hardcoded-test-username"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+<a name="unreleased"></a>
+## [Unreleased]
+
+### Bug Fixes
+- **vars:** Make accountId required, update flows and docs
+
+### Features
+- Add description and changelog optional attributes
+
+<a name="v0.2.0"></a>
+## [v0.2.0] - 2020-05-21
+### Bug Fixes
+- **errors:** Echo using GH Error interface (resolves [#3](https://github.com/newrelic/deployment-marker-action/issues/3))
+
+<a name="v0.1.2"></a>
+## [v0.1.2] - 2020-05-20
+### Bug Fixes
+- wrap github.actor context in quotes, update example, add test workflow
+
+<a name="v0.1.1"></a>
+## [v0.1.1] - 2020-05-19
+### Bug Fixes
+- consistent naming convention style for input attributes
+
+<a name="v0.1.0"></a>
+## [v0.1.0] - 2020-05-19
+### Bug Fixes
+- use correct action reference in example
+
+### Features
+- pass account ID to the deployment request
+- add ability to associate a user to a deployment
+
+<a name="v0.0.1"></a>
+## v0.0.1 - 2020-05-18
+### Bug Fixes
+- adjust URL for market badge
+
+### Documentation Updates
+- minor update for the example
+
+### Features
+- New Relic deployment marker action
+
+[Unreleased]: https://github.com/newrelic/deployment-marker-action/compare/v0.2.0...HEAD
+[v0.2.0]: https://github.com/newrelic/deployment-marker-action/compare/v0.1.2...v0.2.0
+[v0.1.2]: https://github.com/newrelic/deployment-marker-action/compare/v0.1.1...v0.1.2
+[v0.1.1]: https://github.com/newrelic/deployment-marker-action/compare/v0.1.0...v0.1.1
+[v0.1.0]: https://github.com/newrelic/deployment-marker-action/compare/v0.0.1...v0.1.0

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+#############################
+# Global vars
+#############################
+PROJECT_NAME := $(shell basename $(shell pwd))
+PROJECT_VER  ?= $(shell git describe --tags --always --dirty | sed -e '/^v/s/^v\(.*\)$$/\1/g')
+# Last released version (not dirty) without leading v
+PROJECT_VER_TAGGED  := $(shell git describe --tags --always --abbrev=0 | sed -e '/^v/s/^v\(.*\)$$/\1/g')
+
+SRCDIR       ?= .
+RELEASE_SCRIPT ?= ./scripts/release.sh
+
+all:
+	@echo "=== $(PROJECT_NAME) === [ all             ]: Supported targets:"
+	@echo "  release      - Create new release"
+
+
+# Example usage: make release version=0.11.0
+release:
+	@echo "=== $(PROJECT_NAME) === [ release          ]: Generating release."
+	$(RELEASE_SCRIPT) $(version)
+
+
+.PHONY: all build

--- a/README.md
+++ b/README.md
@@ -8,33 +8,76 @@ A GitHub Action to add New Relic deployment markers during your release pipeline
 
 ## Inputs
 
-| Key             |          | Description                                                                                                                              |
-| --------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `apiKey`        | required | Your New Relic [personal API key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#personal-api-key). |
-| `applicationId` | required | The New Relic application ID to apply the deployment marker.                                                                             |
-| `revision`      | required | Metadata to apply to the deployment marker - e.g. the latest release tag                                                                 |
-| `user`          | optional | The user creating the deployment. Default: `github.actor`                                                                                |
-| `region`        | optional | The region of your New Relic account. Default: `US`                                                                                      |
-| `accountId`     | optional | The account number the application falls under. This could also be a subaccount.                                                         |
+| Key             | Required | Description |
+| --------------- | -------- | ----------- |
+| `apiKey`        | **yes** | Your New Relic [personal API key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#personal-api-key). |
+| `accountId`     | **yes** | The account number the application falls under. This could also be a subaccount. |
+| `applicationId` | **yes** | The New Relic application ID to apply the deployment marker. |
+| `revision`      | **yes** | Metadata to apply to the deployment marker - e.g. the latest release tag |
+| `user`          | no | The user creating the deployment. Default: `github.actor` |
+| `region`        | no | The region of your New Relic account. Default: `US` |
 
 ## Example usage
 
+#### Use Release Tag for Revision
+
+The following example could be added as a job to your existing workflow that
+creates a New Relic deployment marker with the revision being the release Tag.
+
+Github secrets assumed to be set:
+* `NEW_RELIC_API_KEY` - Personal API key
+* `NEW_RELIC_APPLIATION_ID` - New Relic Application ID to create the marker on
+
 ```yaml
-# Add a New Relic application deployment marker on release
+name: Release
+
 on:
   - release
 
 jobs:
-  release:
+  newrelic:
     runs-on: ubuntu-latest
+    name: New Relic
     steps:
-      - name: Apply New Relic deployment marker
-        uses: newrelic/deployment-marker-action@master
+      - name: Set Release Version from Tag
+        run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF:10}
+
+      - name: Create New Relic deployment marker
+        uses: newrelic/deployment-marker-action@v1
         with:
           apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
-          applicationId: <your application ID>
+          accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
+          applicationId: ${{ secrets.NEW_RELIC_APPLICATION_ID }}
+          revision: "${{ env.RELEASE_VERSION }}"
+```
+
+#### All input options
+
+Add a New Relic application deployment marker on release, with all of the
+options set.
+
+Github secrets assumed to be set:
+* `NEW_RELIC_API_KEY` - Personal API key
+* `NEW_RELIC_APPLIATION_ID` - New Relic Application ID to create the marker on
+* `NEW_RELIC_ACCOUNT_ID` - New Relic Account ID the application is reporting to
+
+```yaml
+name: Release
+on:
+  - release
+
+jobs:
+  newrelic:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create New Relic deployment marker
+        uses: newrelic/deployment-marker-action@v1
+        with:
+          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+          applicationId: ${{ secrets.NEW_RELIC_APPLIATION_ID }}
           revision: "${{ github.ref }}-${{ github.sha }}"
           user: "${{ github.actor }}"                     # optional
           region: US                                      # optional
-          accountId: <your New Relic account ID>          # optional
+          accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}  # optional
 ```
+

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ jobs:
           revision: "${{ github.ref }}-${{ github.sha }}"
 
           # Optional
-          changelog: "See https://github.com/${{ github.repository }}/CHANGELOG.md for details"
+          changelog: "See https://github.com/${{ github.repository }}/blob/master/CHANGELOG.md for details"
           description: "Automated Deployment via Github Actions"
           region: ${{ secrets.NEW_RELIC_REGION }}
           user: "${{ github.actor }}"

--- a/README.md
+++ b/README.md
@@ -8,14 +8,16 @@ A GitHub Action to add New Relic deployment markers during your release pipeline
 
 ## Inputs
 
-| Key             | Required | Description |
-| --------------- | -------- | ----------- |
-| `apiKey`        | **yes** | Your New Relic [personal API key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#personal-api-key). |
-| `accountId`     | **yes** | The account number the application falls under. This could also be a subaccount. |
-| `applicationId` | **yes** | The New Relic application ID to apply the deployment marker. |
-| `revision`      | **yes** | Metadata to apply to the deployment marker - e.g. the latest release tag |
-| `user`          | no | The user creating the deployment. Default: `github.actor` |
-| `region`        | no | The region of your New Relic account. Default: `US` |
+| Key             | Required | Default | Description |
+| --------------- | -------- | ------- | ----------- |
+| `accountId`     | **yes**  | -       | The account number the application falls under. This could also be a subaccount. |
+| `apiKey`        | **yes**  | -       | Your New Relic [personal API key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#personal-api-key). |
+| `applicationId` | **yes**  | -       | The New Relic application ID to apply the deployment marker. |
+| `changelog`     | no       | -       | A summary of what changed in this deployment, visible in the Deployments page. |
+| `description`   | no       | -       | A high-level description of this deployment, visible in the Overview page and on the Deployments page when you select an individual deployment. |
+| `region`        | no       | `US`    | The region of your New Relic account. Default: `US` |
+| `revision`      | **yes**  | -       | Metadata to apply to the deployment marker - e.g. the latest release tag |
+| `user`          | no       | `github.actor` | A username to associate with the deployment, visible in the Overview page and on the Deployments page. |
 
 ## Example usage
 
@@ -25,6 +27,7 @@ The following example could be added as a job to your existing workflow that
 creates a New Relic deployment marker with the revision being the release Tag.
 
 Github secrets assumed to be set:
+* `NEW_RELIC_ACCOUNT_ID` - Personal API key
 * `NEW_RELIC_API_KEY` - Personal API key
 * `NEW_RELIC_APPLIATION_ID` - New Relic Application ID to create the marker on
 
@@ -57,9 +60,9 @@ Add a New Relic application deployment marker on release, with all of the
 options set.
 
 Github secrets assumed to be set:
+* `NEW_RELIC_ACCOUNT_ID` - New Relic Account ID the application is reporting to
 * `NEW_RELIC_API_KEY` - Personal API key
 * `NEW_RELIC_APPLIATION_ID` - New Relic Application ID to create the marker on
-* `NEW_RELIC_ACCOUNT_ID` - New Relic Account ID the application is reporting to
 
 ```yaml
 name: Release
@@ -73,11 +76,15 @@ jobs:
       - name: Create New Relic deployment marker
         uses: newrelic/deployment-marker-action@v1
         with:
+          accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
           apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
           applicationId: ${{ secrets.NEW_RELIC_APPLIATION_ID }}
           revision: "${{ github.ref }}-${{ github.sha }}"
-          user: "${{ github.actor }}"                     # optional
-          region: US                                      # optional
-          accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}  # optional
+
+          # Optional
+          changelog: "See https://github.com/${{ github.repository }}/CHANGELOG.md for details"
+          description: "Automated Deployment via Github Actions"
+          region: ${{ secrets.NEW_RELIC_REGION }}
+          user: "${{ github.actor }}"
 ```
 

--- a/action.yaml
+++ b/action.yaml
@@ -8,19 +8,19 @@ inputs:
   apiKey:
     description: 'Your New Relic Personal API Key.'
     required: true
-  region:
-    description: 'The geographical region for your New Relic account - US or EU. Default: US'
-    required: false
-    default: US
+  accountId:
+    description: 'Your New Relic account ID. This account ID should have access to the specified application.'
+    required: true
   applicationId:
     description: 'The application ID to apply the deployment marker.'
     required: true
   revision:
     description: 'Custom revision information to add to the deployment marker - e.g. the latest tag.'
     required: true
-  accountId:
-    description: 'Your New Relic account ID. This account ID should have access to the specified application.'
+  region:
+    description: 'The geographical region for your New Relic account - US or EU. Default: US'
     required: false
+    default: US
   user:
     description: 'The user creating the deployment. Default: `github.actor`'
     required: false

--- a/action.yaml
+++ b/action.yaml
@@ -21,6 +21,12 @@ inputs:
     description: 'The geographical region for your New Relic account - US or EU. Default: US'
     required: false
     default: US
+  description:
+    description: 'Description stored with the deployment. Default: <none>'
+    required: false
+  changelog:
+    description: 'Change log string stored with the deployment. Default: <none>'
+    required: false
   user:
     description: 'The user creating the deployment. Default: `github.actor`'
     required: false
@@ -30,8 +36,10 @@ runs:
   image: 'Dockerfile'
   env:
     NEW_RELIC_API_KEY: ${{ inputs.apiKey }}
-    NEW_RELIC_REGION: ${{ inputs.region }}
-    APPLICATION_ID: ${{ inputs.applicationId }}
-    REVISION: ${{ inputs.revision }}
     NEW_RELIC_ACCOUNT_ID: ${{ inputs.accountId }}
+    NEW_RELIC_APPLICATION_ID: ${{ inputs.applicationId }}
+    NEW_RELIC_REGION: ${{ inputs.region }}
     NEW_RELIC_DEPLOYMENT_USER: ${{ inputs.user }}
+    NEW_RELIC_DEPLOYMENT_REVISION: ${{ inputs.revision }}
+    NEW_RELIC_DEPLOYMENT_CHANGE_LOG: ${{ inputs.changelog }}
+    NEW_RELIC_DEPLOYMENT_DESCRIPTION: ${{ inputs.description }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,13 @@
 #!/bin/sh
 
-result=$(newrelic apm deployment create --applicationId "${APPLICATION_ID}" --revision "${REVISION}" --accountId "${NEW_RELIC_ACCOUNT_ID}" --user "${NEW_RELIC_DEPLOYMENT_USER}" 2>&1)
+result=$(newrelic apm deployment create \
+  --accountId "${NEW_RELIC_ACCOUNT_ID}" \
+  --applicationId "${NEW_RELIC_APPLICATION_ID}" \
+  --user "${NEW_RELIC_DEPLOYMENT_USER}" \
+  --revision "${NEW_RELIC_DEPLOYMENT_REVISION}" \
+  --change-log "${NEW_RELIC_DEPLOYMENT_CHANGE_LOG}" \
+  --description "${NEW_RELIC_DEPLOYMENT_DESCRIPTION}" \
+  2>&1)
 
 exitStatus=$?
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+COLOR_RED='\033[0;31m'
+COLOR_NONE='\033[0m'
+CURRENT_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+if [ $CURRENT_GIT_BRANCH != 'master' ]; then
+  printf "\n"
+  printf "${COLOR_RED} Error: The release.sh script must be run while on the master branch. \n ${COLOR_NONE}"
+  printf "\n"
+
+  exit 1
+fi
+
+if [ $# -ne 1 ]; then
+  printf "\n"
+  printf "${COLOR_RED} Error: Release version argument required. \n\n ${COLOR_NONE}"
+  printf " Example: \n\n    ./tools/release.sh 0.9.0 \n\n"
+  printf "  Example (make): \n\n    make release version=0.9.0 \n"
+  printf "\n"
+
+  exit 1
+fi
+
+RELEASE_VERSION=$1
+GIT_USER=$(git config user.email)
+
+echo "Generating release for v${RELEASE_VERSION} using system user git user ${GIT_USER}"
+
+git checkout -b release/v${RELEASE_VERSION}
+
+# Auto-generate CHANGELOG updates
+git-chglog --next-tag v${RELEASE_VERSION} -o CHANGELOG.md
+
+# Commit CHANGELOG updates
+git add CHANGELOG.md
+git commit -m "chore(changelog): Update CHANGELOG for v${RELEASE_VERSION}"
+git push origin release/v${RELEASE_VERSION}


### PR DESCRIPTION
* Set `accountId` as a required input, and update the docs to reflect.
* Update docs to prep for v1 release
