### PR TITLE
Remove set-env in favor of environment variables file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set Release Version from Tag
-        run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF:10}
+        run: echo "RELEASE_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
 
       - name: Test deployment marker
         uses: ./
@@ -21,4 +21,3 @@ jobs:
           accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
           applicationId: ${{ secrets.NEW_RELIC_APPLICATION_ID }}
           revision: "${{ github.repository }}:${{ env.RELEASE_VERSION }}"
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set Release Version from Tag
-        run: echo "RELEASE_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
+        run: echo "RELEASE_VERSION=${{ GITHUB_REF:10 }}" >> $GITHUB_ENV
 
       - name: Test deployment marker
         uses: ./

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ jobs:
     name: New Relic
     steps:
       - name: Set Release Version from Tag
-        run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF:10}
+        run: echo "RELEASE_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
 
       - name: Create New Relic deployment marker
         uses: newrelic/deployment-marker-action@v1
@@ -87,4 +87,3 @@ jobs:
           region: ${{ secrets.NEW_RELIC_REGION }}
           user: "${{ github.actor }}"
 ```
-

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ jobs:
     name: New Relic
     steps:
       - name: Set Release Version from Tag
-        run: echo "RELEASE_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
+        run: echo "RELEASE_VERSION=${{ GITHUB_REF:10 }}" >> $GITHUB_ENV
 
       - name: Create New Relic deployment marker
         uses: newrelic/deployment-marker-action@v1


### PR DESCRIPTION
As of October 1, Github deprecated the `set-env` command in favor of environment variables files: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

All actions using `set-env` from now on produce a warning while executing as can be seen in this image:

<img width="1072" alt="Screen Shot 2020-11-05 at 22 59 31" src="https://user-images.githubusercontent.com/14275767/98317108-a191d800-1fba-11eb-89a8-94607247b704.png">

This PR updates the current example and test workflow to use environment files

Environment files docs: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable

Signed-off-by: B0go <victorbogo@icloud.com>