### PR TITLE
automate release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,22 +1,59 @@
 name: Release
 
+permissions: write-all
+
 on:
   workflow_dispatch:
 
 jobs:
-  basic_test:
+  test:
+    if: github.ref == 'refs/heads/main'
+    uses: newrelic/deployment-marker-action/.github/workflows/test.yml@main
+
+  release:
+    if: github.ref == 'refs/heads/main'
+    needs: test
     runs-on: ubuntu-latest
-    name: Deployment marker example
     steps:
-      - name: Checkout
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18.x
+
+      - name: Add GOBIN to PATH
+        run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+        shell: bash
+
+      - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set Release Version from Tag
-        run: echo "RELEASE_VERSION=${{ GITHUB_REF:10 }}" >> $GITHUB_ENV
+      - name: Release
+        shell: bash
+        run: |
+          git config --global user.name ${{ secrets.NEW_RELIC_GITHUB_SERVICE_ACCOUNT_USERNAME }}
+          git config --global user.email ${{ secrets.NEW_RELIC_GITHUB_SERVICE_ACCOUNT_EMAIL }}
+          
+          chmod +x ./scripts/release-auto.sh
 
-      - name: Test deployment marker
-        uses: ./
+          ./scripts/release-auto.sh
+
+      - name: Get Release Changes
+        id: recentCommits
+        run: |
+          echo ::set-output name=latest_tag::$(git describe --abbrev=0 --tags)
+
+      - name: Checkout code
+        uses: actions/checkout@v3
         with:
-          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
-          guid: ${{ secrets.NEW_RELIC_DEPLOYMENT_ENTITY_GUID }}
-          version: "${{ github.repository }}:${{ env.RELEASE_VERSION }}"
+          ref: ${{ steps.recentCommits.outputs.latest_tag }}
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ steps.recentCommits.outputs.latest_tag }}
+          release_name: ${{ steps.recentCommits.outputs.latest_tag }}
+          draft: false
+          prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,15 +37,15 @@ jobs:
 
           ./scripts/release-auto.sh
 
-      - name: Get Release Changes
-        id: recentCommits
+      - name: Get Latest Tag
+        id: latest_tag
         run: |
-          echo ::set-output name=latest_tag::$(git describe --abbrev=0 --tags)
+          echo ::set-output name=tag::$(git describe --abbrev=0 --tags)
 
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          ref: ${{ steps.recentCommits.outputs.latest_tag }}
+          ref: ${{ steps.latest_tag.outputs.tag }}
 
       - name: Create Release
         id: create_release
@@ -53,7 +53,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
-          tag_name: ${{ steps.recentCommits.outputs.latest_tag }}
-          release_name: ${{ steps.recentCommits.outputs.latest_tag }}
+          tag_name: ${{ steps.latest_tag.outputs.tag }}
+          release_name: ${{ steps.latest_tag.outputs.tag }}
           draft: false
           prerelease: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,11 +6,12 @@ on:
   push:
     branches:
       - master
+  workflow_call:
 
 jobs:
   test_basic:
     runs-on: ubuntu-latest
-    name: Test Basic Usage
+    name: Basic Usage
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -26,7 +27,7 @@ jobs:
 
   test_all_inputs:
     runs-on: ubuntu-latest
-    name: Test All Inputs
+    name: All Inputs
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/scripts/release-auto.sh
+++ b/scripts/release-auto.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+COLOR_RED='\033[0;31m'
+COLOR_NONE='\033[0m'
+
+DEFAULT_BRANCH='main'
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+SCRIPT_NAME=$(basename -- "$0")
+
+echo "Current branch: ${CURRENT_BRANCH}"
+echo "Default branch: ${DEFAULT_BRANCH}"
+
+if [ $CURRENT_BRANCH != $DEFAULT_BRANCH ]; then
+  printf "\n"
+  printf "${COLOR_RED} Error: ${SCRIPT_NAME} must be run on main branch.\n ${COLOR_NONE}"
+  printf "\n"
+  exit 1
+fi
+
+# Set GOBIN env variable for Go dependencies
+GOBIN=$(go env GOPATH)/bin
+
+# Install release dependencies
+go install github.com/caarlos0/svu@latest
+go install github.com/git-chglog/git-chglog/cmd/git-chglog@latest
+go install github.com/client9/misspell/cmd/misspell@latest
+
+VER_CMD=${GOBIN}/svu
+CHANGELOG_CMD=${GOBIN}/git-chglog
+CHANGELOG_FILE=CHANGELOG.md
+SPELL_CMD=${GOBIN}/misspell
+
+# Compare versions
+VER_CURR=$(${VER_CMD} current)
+VER_NEXT=$(${VER_CMD} next)
+
+echo ""
+echo "Comparing tag versions... current: ${VER_CURR}, next: ${VER_NEXT}"
+echo ""
+
+if [ "${VER_CURR}" = "${VER_NEXT}" ]; then
+    VER_NEXT=$(${VER_CMD} patch)
+    printf "Bumping current version ${COLOR_GREEN}${VER_CURR}${COLOR_NONE} to version ${COLOR_LIGHT_GREEN}${VER_NEXT}${COLOR_NONE} for release. "
+fi
+
+GIT_USER=$(git config user.name)
+GIT_EMAIL=$(git config user.email)
+
+if [ -z "${GIT_USER}" ]; then
+  echo "git user.name not set"
+  exit 1
+fi
+
+if [ -z "${GIT_EMAIL}" ]; then
+  echo "git user.email not set"
+  exit 1
+fi
+
+echo "Generating release for ${VER_NEXT} using git user ${GIT_USER}"
+
+# Auto-generate CHANGELOG updates
+${CHANGELOG_CMD} --next-tag ${VER_NEXT} -o ${CHANGELOG_FILE}
+${SPELL_CMD}  -source text -w ${CHANGELOG_FILE}
+
+# Commit CHANGELOG updates
+git add CHANGELOG.md
+git commit --no-verify -m "chore(changelog): Update CHANGELOG for ${VER_NEXT}"
+git push --no-verify origin HEAD:${DEFAULT_BRANCH}
+
+if [ $? -ne 0 ]; then
+  echo "Failed to push branch updates, exiting"
+  exit 1
+fi
+
+# Create and push new tag
+git tag ${VER_NEXT}
+git push --no-verify origin HEAD:${DEFAULT_BRANCH} --tags
+
+if [ $? -ne 0 ]; then
+  echo "Failed to push tag, exiting"
+  exit $?
+fi


### PR DESCRIPTION
Update from `manual` to an automated approach for releases. Added `release-auto.sh` as an alternative to `release.sh` to not disrupt the current process in case the new automated one needs troubleshooting or tune up.