### PR TITLE
feat: add deployment id to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,4 +126,7 @@ jobs:
           deploymentType: "ROLLING"
           groupId: "Workshop App Release: ${{ github.ref_name }}"
           user: "${{ github.actor }}"
+      # When chaining steps together, the deployment id is placeed into the github environment 
+      - name: View output
+        run: echo "${{ env.deploymentId }}"
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -41,6 +41,9 @@ inputs:
   groupid:
     description: 'Group Id used to link deployments together.'
     required: false
+outputs:
+  deploymentId:
+    description: 'The id of the deployment'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,4 +20,7 @@ if [ $exitStatus -ne 0 ]; then
   echo "::error:: $result"
 fi
 
+deploymentId=$(echo "$result" | grep deploymentId | cut -d '"' -f4- | cut -d '"' -f1)
+echo "deploymentId=$deploymentId" >> $GITHUB_ENV
+
 exit $exitStatus


### PR DESCRIPTION
Adds output of the deployment Id so you can pass it to subsequent steps. 

<img width="451" alt="image" src="https://user-images.githubusercontent.com/110412864/223591621-f2401d41-79bf-4bf8-868b-3e9d207636f2.png">

