### PR TITLE
fix: code refactor to return the right error status and doc changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+.idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ jobs:
           changelog: "https://github.com/${{ github.repository }}/blob/master/CHANGELOG.md"
           commit: "${{ github.sha }}"
           description: "Automated Release via Github Actions"
-          deploymentType: "ROLLING"
+          deploymenttype: "ROLLING"
           groupId: "Workshop App Release: ${{ github.ref_name }}"
           user: "${{ github.actor }}"
       # This step creates a new Change Tracking Marker for App
@@ -109,7 +109,7 @@ jobs:
           changelog: "https://github.com/${{ github.repository }}/blob/master/CHANGELOG.md"
           commit: "${{ github.sha }}"
           description: "Automated Release via Github Actions"
-          deploymentType: "ROLLING"
+          deploymenttype: "ROLLING"
           groupId: "Workshop App Release: ${{ github.ref_name }}"
           user: "${{ github.actor }}"
       # This step creates a new Change Tracking Marker for App789
@@ -123,7 +123,7 @@ jobs:
           changelog: "https://github.com/${{ github.repository }}/blob/master/CHANGELOG.md"
           commit: "${{ github.sha }}"
           description: "Automated Release via Github Actions"
-          deploymentType: "ROLLING"
+          deploymenttype: "ROLLING"
           groupId: "Workshop App Release: ${{ github.ref_name }}"
           user: "${{ github.actor }}"
       # When chaining steps together, the deployment id is placeed into the github environment 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,9 +12,8 @@ result=$(newrelic entity deployment create \
   --groupId "${NEW_RELIC_DEPLOYMENT_GROUP_ID}" \
   2>&1)
 
-echo "$result"
-
 exitStatus=$?
+echo "$result"
 
 if [ $exitStatus -ne 0 ]; then
   echo "::error:: $result"


### PR DESCRIPTION
This PR addresses fixes to the following issues.

#40 : 
- Summary: Job status being marked as **Success** in the event of a failure too, which I've been able to reproduce by specifying wrong credentials and a wrong GUID to run `entrypoint.sh`, as specified by the user. 
- This is possibly due to an improper positioning of `exitStatus=$?` in `entrypoint.sh`, which is why it was not receiving status `1` in the event of an error. This has been refactored.

#41 :
- Summary: `action.yaml` specifies the deployment type input as `deploymenttype`, but this input has been specified as `deploymentType` in the examples in `README.md`. This typo has been fixed.

### Changes made to fix #40 :

#### Before Changes

<img width="1074" alt="image" src="https://github.com/newrelic/deployment-marker-action/assets/127438038/706e296b-b8d4-47be-91bc-80fc819bb1c2">

<img width="1197" alt="image" src="https://github.com/newrelic/deployment-marker-action/assets/127438038/e2b42833-7d14-4415-abb1-7ff0e3aed3e3">

#### After Changes

<img width="1428" alt="image" src="https://github.com/newrelic/deployment-marker-action/assets/127438038/20c3abc9-593d-4d04-bdb3-cdf054169080">

<img width="1582" alt="image" src="https://github.com/newrelic/deployment-marker-action/assets/127438038/9628f1b4-7faa-43c9-b3ba-3fec463dcb7b">
