### PR TITLE
docs: fix deep link parameter casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ A GitHub Action to add New Relic deployment markers during your release pipeline
 | `guid`           | **yes**  | -       | The entity GUID to apply the deployment marker. |
 | `apiKey`         | **yes**  | -       | Your New Relic [personal API key](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#personal-api-key). |
 | `changelog`      | no       | -       | A summary of what changed in this deployment, visible in the Deployments page. |
-| `commit`      | no       | -       | The Commit SHA for this deployment, visible in the Deployments page. |
+| `commit`         | no       | -       | The Commit SHA for this deployment, visible in the Deployments page. |
 | `description`    | no       | -       | A high-level description of this deployment, visible in the Overview page and on the Deployments page when you select an individual deployment. |
-| `deeplink`       | no       | -       | A deep link to the source which triggered the deployment. |
+| `deepLink`       | no       | -       | A deep link to the source which triggered the deployment. |
 | `deploymentType` | no       | `BASIC` | The type of deployment. Choose from BASIC, BLUE_GREEN, CANARY, OTHER, ROLLING, or SHADOW. |
 | `groupId`        | no       | -       | A group ID for the deployment to link to other deployments. |
 | `region`         | no       | `US`    | The region of your New Relic account. Default: `US` |


### PR DESCRIPTION
Fixes incorrect casing for deep link parameter in the README

Before: `--deeplink`
After: `--deepLink`