### PR TITLE
fix #51 - use a tagged version of the cli container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM newrelic/cli:latest
+FROM newrelic/cli:v0.73.6
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 # COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
This fixes the immediate issue from the bad release of cli v0.74, but will also prevent future problems with cli releases and possible supply chain attacks on that dependency.

Don't float your dependencies!