### PR TITLE
chore(release): add RELEASE_TOKEN to the environment of the release task

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Release
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           git config --global user.name ${{ secrets.NEW_RELIC_GITHUB_SERVICE_ACCOUNT_USERNAME }}
           git config --global user.email ${{ secrets.NEW_RELIC_GITHUB_SERVICE_ACCOUNT_EMAIL }}


### PR DESCRIPTION
Our `release-auto.sh` (Release Script) doesn't seem to be working when triggered by the release workflow `release.yml`, and is failing with an error which hints at the fact that an unauthorized (non-bot) GitHub user is trying to perform the release. 

It is clear from the rest of the configuration that the username and email of the user configured to perform the release are that of our DTK Bot, but this still doesn't seem to be working, hinting at the fact that this could be possibly an issue caused by a missing `RELEASE_TOKEN`; hence the update. See the comment below for more info.