### PR TITLE
fix: change tracking issue with timestamp

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,25 @@ jobs:
           region: ${{ secrets.NEW_RELIC_REGION }}
           user: "${{ github.actor }}"
 
+  # This job tests the change tracking create event with mandatory input fields.
+  test_change_tracking_basic_inputs:
+    runs-on: ubuntu-latest
+    name: Change Tracking - Basic Inputs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Test change event deployment marker
+        uses: ./
+        with:
+          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+          category: 'Deployment'
+          commandType: "changeTrackingCreateEvent"
+          entitySearch: "id='${{ secrets.NEW_RELIC_DEPLOYMENT_ENTITY_GUID }}'"
+          region: ${{ secrets.NEW_RELIC_REGION }}
+          type: 'Basic'
+          user: "${{ github.actor }}"
+          version: "deployment-marker-action-basic-test:${{ github.ref }}"
+
   # This job tests the change tracking create event with category 'Feature Flag' and uses customAttributes with JS object format.
   # For more details on change tracking event mutation, please refer to our [docs](https://docs.newrelic.com/docs/change-tracking/change-tracking-events/#change-tracking-event-mutation)
   test_change_tracking:
@@ -72,7 +91,6 @@ jobs:
           timestamp: "${{ steps.timestamp.outputs.NOW_MS }}"
           type: 'Basic'
           user: "${{ github.actor }}"
-          version: "deployment-marker-action-basic-test:${{ github.ref }}"
 
   # This job tests the change tracking create event with category 'DEPLOYMENT' and uses customAttributes file with JS object format.
   test_change_tracking_with_custom_attributes_file:
@@ -115,10 +133,11 @@ jobs:
         id: timestamp
         run: echo "NOW_MS=$(date +%s%3N)" >> $GITHUB_OUTPUT
       - name: Load .env file
-        uses: aarcangeli/load-dotenv@v1 # This action loads the .env file
+        uses: aarcangeli/load-dotenv@v1.1.0 # This action loads the .env file
         with:
-          filename: .env
-        continue-on-error: true
+          filenames: .env
+          path: '.'
+          if-file-not-found: 'ignore'
       - name: Set entity name
         id: set_entity_name
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM newrelic/cli:v0.104.0
+FROM newrelic/cli:v0.104.5
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 # COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ jobs:
           type: 'Basic'
           changelog: "https://github.com/${{ github.repository }}/blob/master/CHANGELOG.md"
           commit: "${{ github.sha }}"
-          deepLink: "https://example.com/deployment"
+          deeplink: "https://example.com/deployment"
           description: "Automated Release via Github Actions"
           user: "${{ github.actor }}"
-          groupId: "deploy-group-1"
+          groupid: "deploy-group-1"
           timestamp: "${{ github.event.release.published_at }}"
           customAttributes: '{cloud_vendor: "vendor_name", region: "us-east-1", isProd: true, instances: 2}'
 ```
@@ -167,7 +167,7 @@ jobs:
           commit: "${{ github.sha }}"
           description: "Automated Release via Github Actions"
           deploymenttype: "ROLLING"
-          groupId: "Workshop App Release: ${{ github.ref_name }}"
+          groupid: "Workshop App Release: ${{ github.ref_name }}"
           user: "${{ github.actor }}"
       # This step creates a new Change Tracking Marker for App
       - name: App456 Marker
@@ -181,7 +181,7 @@ jobs:
           commit: "${{ github.sha }}"
           description: "Automated Release via Github Actions"
           deploymenttype: "ROLLING"
-          groupId: "Workshop App Release: ${{ github.ref_name }}"
+          groupid: "Workshop App Release: ${{ github.ref_name }}"
           user: "${{ github.actor }}"
       # This step creates a new Change Tracking Marker for App789
       - name: App789 Marker
@@ -195,7 +195,7 @@ jobs:
           commit: "${{ github.sha }}"
           description: "Automated Release via Github Actions"
           deploymenttype: "ROLLING"
-          groupId: "Workshop App Release: ${{ github.ref_name }}"
+          groupid: "Workshop App Release: ${{ github.ref_name }}"
           user: "${{ github.actor }}"
       # When chaining steps together, the deployment id is placed into the GitHub environment 
       - name: View output

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,48 +1,127 @@
 #!/bin/sh
 
+# This script creates a New Relic Change Tracking or Deployment event.
+
 if [ "${NEW_RELIC_COMMAND_TYPE}" = "changeTrackingCreateEvent" ]; then
 
-    # Validation for createEvent API when category is set to Deployment
-    if [ "${NEW_RELIC_CREATE_EVENT_CATEGORY}" = "Deployment" ]; then
-      if [ -z "${NEW_RELIC_DEPLOYMENT_VERSION}" ]; then
-        echo "::error::'version' is mandatory for createEvent API when category is set to 'Deployment'."
-        exit 1
+  # --- Mandatory field validations based on the API schema ---
+  if [ -z "${NEW_RELIC_CREATE_EVENT_CATEGORY}" ]; then
+    echo "::error::'category' is a mandatory field based on the API schema."
+    exit 1
+  fi
+  if [ -z "${NEW_RELIC_CREATE_EVENT_TYPE}" ]; then
+    echo "::error::'type' is a mandatory field based on the API schema."
+    exit 1
+  fi
+  if [ -z "${NEW_RELIC_CREATE_EVENT_ENTITY_SEARCH}" ]; then
+    echo "::error::'entitySearch' is a mandatory field based on the API schema."
+    exit 1
+  fi
+
+  # --- Conditional mandatory field validations ---
+  if [ "${NEW_RELIC_CREATE_EVENT_CATEGORY}" = "Deployment" ]; then
+    if [ -z "${NEW_RELIC_DEPLOYMENT_VERSION}" ]; then
+      echo "::error::'version' is mandatory for a 'Deployment' category event."
+      exit 1
+    fi
+  fi
+
+  if [ "${NEW_RELIC_CREATE_EVENT_CATEGORY}" = "Feature Flag" ]; then
+    if [ -z "${NEW_RELIC_CREATE_EVENT_FEATURE_FLAG_ID}" ]; then
+      echo "::error::'featureFlagId' is mandatory for a 'Feature Flag' category event."
+      exit 1
+    fi
+  fi
+
+  # -- Conditional validations based on Category type ---
+  if [ "${NEW_RELIC_CREATE_EVENT_CATEGORY}" != "Deployment" ]; then
+    invalid_fields=""
+        if [ -n "${NEW_RELIC_DEPLOYMENT_VERSION}" ]; then
+          invalid_fields="version"
+        fi
+        if [ -n "${NEW_RELIC_DEPLOYMENT_CHANGE_LOG}" ]; then
+          if [ -n "${invalid_fields}" ]; then
+            invalid_fields="${invalid_fields}, changelog"
+          else
+            invalid_fields="changelog"
+          fi
+        fi
+        if [ -n "${NEW_RELIC_DEPLOYMENT_COMMIT}" ]; then
+          if [ -n "${invalid_fields}" ]; then
+            invalid_fields="${invalid_fields}, commit"
+          else
+            invalid_fields="commit"
+          fi
+        fi
+        if [ -n "${NEW_RELIC_DEPLOYMENT_DEEPLINK}" ]; then
+          if [ -n "${invalid_fields}" ]; then
+            invalid_fields="${invalid_fields}, deeplink"
+          else
+            invalid_fields="deeplink"
+          fi
+        fi
+        if [ -n "${invalid_fields}" ]; then
+          echo "::error::${invalid_fields} can only be used with Deployment events."
+          exit 1
+        fi
       fi
+
+    if [ "${NEW_RELIC_CREATE_EVENT_CATEGORY}" != "Feature Flag" ] && [ -n "${NEW_RELIC_CREATE_EVENT_FEATURE_FLAG_ID}" ]; then
+      echo "::error::'featureFlagId' is only valid for 'Feature Flag' category events."
+      exit 1
     fi
 
-    # Validation for createEvent API when category is set to Feature Flag
-    if [ "${NEW_RELIC_CREATE_EVENT_CATEGORY}" = "Feature Flag" ]; then
-      if [ -z "${NEW_RELIC_CREATE_EVENT_FEATURE_FLAG_ID}" ]; then
-        echo "::error::'featureFlagId' is mandatory for createEvent API when category is set to 'Feature Flag'."
-        exit 1
-      fi
-    fi
+  # --- Build the command string, conditionally adding optional fields ---
+  command_str="newrelic changeTracking create \
+    --category \"${NEW_RELIC_CREATE_EVENT_CATEGORY}\" \
+    --entitySearch \"${NEW_RELIC_CREATE_EVENT_ENTITY_SEARCH}\" \
+    --type \"${NEW_RELIC_CREATE_EVENT_TYPE}\""
 
-  # Execute New Relic changeTrackingCreateEvent command
-  result=$(newrelic changeTracking create \
-    --category "${NEW_RELIC_CREATE_EVENT_CATEGORY}" \
-    --changelog "${NEW_RELIC_DEPLOYMENT_CHANGE_LOG}" \
-    --commit "${NEW_RELIC_DEPLOYMENT_COMMIT}" \
-    --customAttributes "${NEW_RELIC_CREATE_EVENT_CUSTOM_ATTRIBUTES}" \
-    --deepLink "${NEW_RELIC_DEPLOYMENT_DEEPLINK}" \
-    --description "${NEW_RELIC_DEPLOYMENT_DESCRIPTION}" \
-    --entitySearch "${NEW_RELIC_CREATE_EVENT_ENTITY_SEARCH}" \
-    --featureFlagId "${NEW_RELIC_CREATE_EVENT_FEATURE_FLAG_ID}" \
-    --groupId "${NEW_RELIC_DEPLOYMENT_GROUP_ID}" \
-    --shortDescription "${NEW_RELIC_CREATE_EVENT_SHORT_DESCRIPTION}" \
-    --timestamp "${NEW_RELIC_CREATE_EVENT_TIMESTAMP}" \
-    --type "${NEW_RELIC_CREATE_EVENT_TYPE}" \
-    --user "${NEW_RELIC_DEPLOYMENT_USER}" \
-    --validationFlags "${NEW_RELIC_CREATE_EVENT_VALIDATION_FLAGS}" \
-    --version "${NEW_RELIC_DEPLOYMENT_VERSION}" \
-    2>&1)
+  if [ -n "${NEW_RELIC_DEPLOYMENT_CHANGE_LOG}" ]; then
+    command_str="${command_str} --changelog \"${NEW_RELIC_DEPLOYMENT_CHANGE_LOG}\""
+  fi
+  if [ -n "${NEW_RELIC_DEPLOYMENT_COMMIT}" ]; then
+    command_str="${command_str} --commit \"${NEW_RELIC_DEPLOYMENT_COMMIT}\""
+  fi
+  if [ -n "${NEW_RELIC_CREATE_EVENT_CUSTOM_ATTRIBUTES}" ]; then
+    command_str="${command_str} --customAttributes '${NEW_RELIC_CREATE_EVENT_CUSTOM_ATTRIBUTES}'"
+  fi
+  if [ -n "${NEW_RELIC_DEPLOYMENT_DEEPLINK}" ]; then
+    command_str="${command_str} --deepLink \"${NEW_RELIC_DEPLOYMENT_DEEPLINK}\""
+  fi
+  if [ -n "${NEW_RELIC_DEPLOYMENT_DESCRIPTION}" ]; then
+    command_str="${command_str} --description \"${NEW_RELIC_DEPLOYMENT_DESCRIPTION}\""
+  fi
+  if [ -n "${NEW_RELIC_DEPLOYMENT_GROUP_ID}" ]; then
+    command_str="${command_str} --groupId \"${NEW_RELIC_DEPLOYMENT_GROUP_ID}\""
+  fi
+  if [ -n "${NEW_RELIC_CREATE_EVENT_SHORT_DESCRIPTION}" ]; then
+    command_str="${command_str} --shortDescription \"${NEW_RELIC_CREATE_EVENT_SHORT_DESCRIPTION}\""
+  fi
+  if [ -n "${NEW_RELIC_CREATE_EVENT_TIMESTAMP}" ]; then
+    command_str="${command_str} --timestamp \"${NEW_RELIC_CREATE_EVENT_TIMESTAMP}\""
+  fi
+  if [ -n "${NEW_RELIC_DEPLOYMENT_USER}" ]; then
+    command_str="${command_str} --user \"${NEW_RELIC_DEPLOYMENT_USER}\""
+  fi
+  if [ -n "${NEW_RELIC_CREATE_EVENT_VALIDATION_FLAGS}" ]; then
+    command_str="${command_str} --validationFlags \"${NEW_RELIC_CREATE_EVENT_VALIDATION_FLAGS}\""
+  fi
+  if [ -n "${NEW_RELIC_DEPLOYMENT_VERSION}" ]; then
+    command_str="${command_str} --version \"${NEW_RELIC_DEPLOYMENT_VERSION}\""
+  fi
+  if [ -n "${NEW_RELIC_CREATE_EVENT_FEATURE_FLAG_ID}" ]; then
+    command_str="${command_str} --featureFlagId \"${NEW_RELIC_CREATE_EVENT_FEATURE_FLAG_ID}\""
+  fi
+
+  result=$(eval "$command_str" 2>&1)
 
 else
   # Validation for createDeployment API
-    if [ -z "${NEW_RELIC_DEPLOYMENT_VERSION}" ]; then
-      echo "::error::'version' is mandatory for createDeployment API."
-      exit 1
-    fi
+  if [ -z "${NEW_RELIC_DEPLOYMENT_VERSION}" ]; then
+    echo "::error::'version' is mandatory for createDeployment API."
+    exit 1
+  fi
 
   # Execute New Relic entity deployment command
   result=$(newrelic entity deployment create \


### PR DESCRIPTION
https://new-relic.atlassian.net/browse/NR-462495

This PR addresses an issue with timestamp as reported in this Github [issue](https://github.com/newrelic/deployment-marker-action/issues/85).

Additionally, when trying to create new change tracking events (`createChangeTrackingCreateEvent`), if there are any optional params not specified in the inputs (test.yml), we’re passing null/empty values to the CLI that is being executed. While this doesn't cause any erroneous outcomes, this PR improves the way we handle adding validations and conditionally include arguments in the CLI command only if they are explicitly provided (i.e., not null), thereby enhancing the action's efficiency.

### Before: 
<img width="1637" height="311" alt="image" src="https://github.com/user-attachments/assets/83cf564f-ef19-4cca-90b4-423154096c5a" />

### After:
<img width="1634" height="354" alt="image" src="https://github.com/user-attachments/assets/2f583690-85bc-48b3-90d6-167896ce5f37" />

